### PR TITLE
Separate services for organizations and members

### DIFF
--- a/app/api/joinrequests/route.ts
+++ b/app/api/joinrequests/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { auth } from "@/lib/auth";
 import { JoinRequestStatus, JOIN_REQUEST_STATUS_VALUES } from "@/lib/schema";
 import { JoinRequestsService } from "@/lib/services/joinRequests";
+import { MembersService } from "@/lib/services/members";
 
 // Schema for GET pagination parameters
 const getParamsSchema = z.object({
@@ -57,12 +58,12 @@ export async function GET(request: Request) {
   }
 
   // Check if user is admin or owner of the active organization
-  const membership = await JoinRequestsService.getUserMembership(
+  const membership = await MembersService.findByUserAndOrganization(
     session.user.id,
     activeOrganizationId,
   );
 
-  if (!JoinRequestsService.isAdminOrOwner(membership?.role)) {
+  if (!MembersService.isAdminOrOwner(membership?.role)) {
     return NextResponse.json(
       { error: "Forbidden: Admin or owner role required" },
       { status: 403 },
@@ -118,12 +119,12 @@ export async function PATCH(request: Request) {
   }
 
   // Check if user is admin or owner of the active organization
-  const membership = await JoinRequestsService.getUserMembership(
+  const membership = await MembersService.findByUserAndOrganization(
     session.user.id,
     activeOrganizationId,
   );
 
-  if (!JoinRequestsService.isAdminOrOwner(membership?.role)) {
+  if (!MembersService.isAdminOrOwner(membership?.role)) {
     return NextResponse.json(
       { error: "Forbidden: Admin or owner role required" },
       { status: 403 },

--- a/lib/authUtils.ts
+++ b/lib/authUtils.ts
@@ -1,4 +1,6 @@
 import { JoinRequestsService } from "@/lib/services/joinRequests";
+import { MembersService } from "@/lib/services/members";
+import { OrganizationsService } from "@/lib/services/organizations";
 
 const defaultOrganizationSlug = "servicestart";
 
@@ -14,10 +16,10 @@ export function getSlugFromHost(host?: string): string {
 export async function createJoinRequestIfNeeded(userId: string, host?: string) {
   const slug = getSlugFromHost(host);
 
-  const organization = await JoinRequestsService.findOrganizationBySlug(slug);
+  const organization = await OrganizationsService.findBySlug(slug);
   if (!organization) return;
 
-  const membership = await JoinRequestsService.getUserMembership(
+  const membership = await MembersService.findByUserAndOrganization(
     userId,
     organization.id,
   );

--- a/lib/services/joinRequests.ts
+++ b/lib/services/joinRequests.ts
@@ -1,12 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { and, eq } from "drizzle-orm";
 import db from "@/lib/db";
-import {
-  joinRequests,
-  JoinRequestStatus,
-  members,
-  organizations,
-} from "@/lib/schema";
+import { joinRequests, JoinRequestStatus } from "@/lib/schema";
 
 async function findByUserAndOrganization(
   userId: string,
@@ -108,36 +103,6 @@ async function deleteById(joinRequestId: string) {
   await db.delete(joinRequests).where(eq(joinRequests.id, joinRequestId));
 }
 
-async function getUserMembership(userId: string, organizationId: string) {
-  const [membership] = await db
-    .select({ role: members.role })
-    .from(members)
-    .where(
-      and(
-        eq(members.userId, userId),
-        eq(members.organizationId, organizationId),
-      ),
-    )
-    .limit(1);
-
-  return membership ?? null;
-}
-
-function isAdminOrOwner(role: string | undefined): boolean {
-  const ADMIN_ROLES = ["admin", "owner"];
-  return role !== undefined && ADMIN_ROLES.includes(role);
-}
-
-async function findOrganizationBySlug(slug: string) {
-  const [organization] = await db
-    .select({ id: organizations.id })
-    .from(organizations)
-    .where(eq(organizations.slug, slug))
-    .limit(1);
-
-  return organization ?? null;
-}
-
 async function create(userId: string, organizationId: string) {
   const id = randomUUID();
   await db.insert(joinRequests).values({
@@ -156,8 +121,5 @@ export const JoinRequestsService = {
   listByOrganization,
   updateStatus,
   deleteById,
-  getUserMembership,
-  isAdminOrOwner,
-  findOrganizationBySlug,
   create,
 };

--- a/lib/services/members.ts
+++ b/lib/services/members.ts
@@ -1,0 +1,31 @@
+import { and, eq } from "drizzle-orm";
+import db from "@/lib/db";
+import { members } from "@/lib/schema";
+
+async function findByUserAndOrganization(
+  userId: string,
+  organizationId: string,
+) {
+  const [membership] = await db
+    .select({ id: members.id, role: members.role })
+    .from(members)
+    .where(
+      and(
+        eq(members.userId, userId),
+        eq(members.organizationId, organizationId),
+      ),
+    )
+    .limit(1);
+
+  return membership ?? null;
+}
+
+function isAdminOrOwner(role: string | undefined): boolean {
+  const ADMIN_ROLES = ["admin", "owner"];
+  return role !== undefined && ADMIN_ROLES.includes(role);
+}
+
+export const MembersService = {
+  findByUserAndOrganization,
+  isAdminOrOwner,
+};

--- a/lib/services/organizations.ts
+++ b/lib/services/organizations.ts
@@ -1,0 +1,17 @@
+import { eq } from "drizzle-orm";
+import db from "@/lib/db";
+import { organizations } from "@/lib/schema";
+
+async function findBySlug(slug: string) {
+  const [organization] = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(eq(organizations.slug, slug))
+    .limit(1);
+
+  return organization ?? null;
+}
+
+export const OrganizationsService = {
+  findBySlug,
+};


### PR DESCRIPTION
## Summary

- Refactored database query logic into dedicated service files for better separation of concerns

## Changes

### New Services
- **`lib/services/organizations.ts`** - `OrganizationsService` for organization-related queries
  - `findBySlug(slug)` - Find an organization by its slug
  
- **`lib/services/members.ts`** - `MembersService` for membership-related queries
  - `findByUserAndOrganization(userId, organizationId)` - Check if a user is a member
  - `isAdminOrOwner(role)` - Check if a role has admin/owner permissions

### Refactored Files
- **`lib/services/joinRequests.ts`** - Removed organization and member queries (moved to dedicated services)
- **`lib/authUtils.ts`** - Now uses `OrganizationsService` and `MembersService` instead of direct DB calls
- **`app/api/joinrequests/route.ts`** - Now uses `MembersService` for authorization checks

**Checklist:**

- [X] I have mentioned a ticket above
- [X] My changes meet the acceptance criteria of said ticket
- [X] I have self-reviewed my changes
- [X] I have requested a review from the appropriate team member(s)
