### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/GTBitsOfGood/servicestart/security/code-scanning/9](https://github.com/GTBitsOfGood/servicestart/security/code-scanning/9)

In general, the fix is to add an explicit `permissions` block that restricts the `GITHUB_TOKEN` to the minimal rights needed. Since all jobs here only need to read repository contents (for `actions/checkout`) and do not interact with issues, pull requests, or other GitHub resources, the minimal appropriate permissions are `contents: read`. Adding this at the top (workflow scope) applies to all jobs that don’t override permissions, which matches the current usage.

Concretely, in `.github/workflows/ci.yml`, add a root-level `permissions:` block immediately after the `name: CI` line. This will ensure all jobs (`build`, `test`, `e2e`, `e2e-all`, `lint`, `format`, `check-migrations`, etc.) run with `contents: read` only. No other changes, imports, or definitions are required, and existing functionality is preserved because none of the jobs perform write operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
