### PR TITLE
Use build in E2E tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -79,7 +79,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: "pnpm dev",
+    command: "pnpm run build && pnpm run start",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,


### PR DESCRIPTION
Switches the command Playwright uses from "pnpm dev" to "pnpm run build && pnpm run start."